### PR TITLE
Undefined name: import os in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Train the model
 """
 import importlib
+import os
 import numpy as np
 import tensorflow as tf
 from config import CONFIG


### PR DESCRIPTION
__os__ is used several times in __main.py__ but it is never imported or defined.

flake8 testing of https://github.com/llSourcell/AI_For_Music_Composition on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./main.py:21:12: F821 undefined name 'os'
        if os.path.isabs(CONFIG['data']['training_data_location']):
           ^
./main.py:24:24: F821 undefined name 'os'
            filepath = os.path.abspath(os.path.join(
                       ^
./main.py:24:40: F821 undefined name 'os'
            filepath = os.path.abspath(os.path.join(
                                       ^
./main.py:25:17: F821 undefined name 'os'
                os.path.realpath(__file__), 'training_data',
                ^
./v1/training/tracks_parsing.py:70:12: F821 undefined name 'MODE'
        if MODE == '2D':
           ^
./v1/training/tracks_parsing.py:72:14: F821 undefined name 'MODE'
        elif MODE == '3D':
             ^
6     F821 undefined name 'os'
6
```